### PR TITLE
generate fern definition

### DIFF
--- a/fern/api/definition/api.yml
+++ b/fern/api/definition/api.yml
@@ -1,6 +1,8 @@
 name: api
-auth: bearer
+display-name: CodeCombat API
+auth: basic
 environments:
-  Production: https://api.example.com
-  Sandbox: https://sandbox.example.com
+  Production: https://codecombat.com/api 
 default-environment: Production
+error-discrimination:
+  strategy: status-code

--- a/fern/api/definition/auth.yml
+++ b/fern/api/definition/auth.yml
@@ -1,0 +1,29 @@
+services:
+  http:
+    AuthService:
+      auth: true
+      base-path: /auth
+      endpoints:
+        get:
+          docs: Logs a user in.
+          path: /login-o-auth
+          method: GET
+          request: 
+            name: LoginUserRequest
+            query-parameters:
+              provider: 
+                type: string
+                docs: Your OAuth Provider ID
+              accessToken: 
+                type: optional<string>
+                docs: Will be passed through your lookup URL to get the user ID. Required if no code.
+              code: 
+                type: optional<string>
+                docs: Will be passed to the OAuth token endpoint to get a token. Required if no accessToken.
+              redirect: 
+                type: optional<string>
+                docs: Override where the user will navigate to after successfully logging in.
+              errorRedirect: 
+                type: optional<string> 
+                docs: | 
+                  If an error happens, redirects the user to this url, with at least query parameters code, errorName and message.

--- a/fern/api/definition/clans.yml
+++ b/fern/api/definition/clans.yml
@@ -1,0 +1,40 @@
+imports: 
+  commons: commons.yml
+
+types:
+  ClanResponse:
+    docs: Subset of properties listed here
+    properties:
+      _id: optional<commons.ObjectId>
+      name: optional<string>
+      displayName: optional<string>
+      members: optional<list<commons.ObjectId>>
+      ownerID: optional<commons.ObjectId>
+      description: optional<string>
+      type: optional<string>
+      kind: optional<string>
+
+services:
+  http:
+    ClansService:
+      auth: true
+      base-path: /clan
+      endpoints:
+        put:
+          path: /{handle}/members
+          method: PUT
+          docs: Upserts a user into the clan.
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: ClanRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body:
+              properties:
+                userId: string
+          response: ClanResponse

--- a/fern/api/definition/classrooms.yml
+++ b/fern/api/definition/classrooms.yml
@@ -1,0 +1,230 @@
+imports: 
+  commons: commons.yml
+
+services:
+  http:
+    ClassroomsService:
+      auth: true
+      base-path: /classrooms
+      endpoints:
+        get:
+          path: ""
+          method: GET
+          docs: Returns the classroom details for a class code.
+          response: ClassroomResponseWithCode
+        
+        create:
+          path: ""
+          method: POST
+          docs: Creates a new empty `Classroom`.
+          request:
+            name: CreateClassroomRequest
+            body:
+              properties:
+                name: string
+                ownerID: commons.ObjectId
+                aceConfig: AceConfig
+
+        upsert:
+          path: /{handle}/members
+          method: PUT
+          docs: Upserts a user into the classroom.
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: UpsertClassroomRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body:
+              properties:
+                code: string
+                userId: string
+                retMemberLimit: optional<double>
+          response: commons.ClassroomResponse
+
+        removeUser:
+          path: /{handle}/members
+          method: DELETE
+          docs: Remove a user from the classroom.
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: RemoveUserRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body:
+              properties:
+                userId: string
+                retMemberLimit: optional<double>
+          response: commons.ClassroomResponse
+
+        enrollUser:
+          path: /{classroomHandle}/courses/{courseHandle}/enrolled
+          method: PUT
+          docs: |
+            Enrolls a user in a course in a classroom.
+            If the course is paid, user must have an active license.
+            User must be a member of the classroom.
+          path-parameters:
+            classroomHandle:
+              docs: The classroom's `_id`.
+              type: string
+            courseHandle:
+              docs: The course's `_id`.
+              type: string
+          request:
+            name: EnrollUserRequest
+            query-parameters:
+              classroomHandle:
+                docs: The classroom's `_id`.
+                type: string
+              courseHandle:
+                docs: The course's `_id`.
+                type: string
+            body:
+              properties:
+                userId: commons.ObjectId
+          response: commons.ClassroomResponse
+
+        unenrollUser:
+          path: /{classroomHandle}/courses/{courseHandle}/remove-enrolled
+          method: PUT
+          docs: |
+            Removes an enrolled user from a course in a classroom.
+          path-parameters:
+            classroomHandle:
+              docs: The classroom's `_id`.
+              type: string
+            courseHandle:
+              docs: The course's `_id`.
+              type: string
+          request:
+            name: UnenrollUserRequest
+            query-parameters:
+              classroomHandle:
+                docs: The classroom's `_id`.
+                type: string
+              courseHandle:
+                docs: The course's `_id`.
+                type: string
+            body:
+              properties:
+                userId: commons.ObjectId
+          response: commons.ClassroomResponse
+
+        getStats:
+          path: /{classroomHandle}/stats
+          method: GET
+          docs: |
+            Returns a list of all members stats for the classroom.
+          path-parameters:
+            classroomHandle:
+              docs: The classroom's `_id`.
+              type: string
+          request:
+            name: ClassroomStatsRequest
+            query-parameters:
+              classroomHandle:
+                docs: The classroom's `_id`.
+                type: string
+          response: list<ClassroomStats>
+          
+        getLevelsPlayedForUser:
+          path: /{classroomHandle}/members/{memberHandle}/sessions
+          method: GET
+          docs: |
+            Returns a list of all levels played by the user for the classroom.
+          path-parameters:
+            classroomHandle:
+              docs: The classroom's `_id`.
+              type: string
+            memberHandle:
+              docs: The classroom member's `_id`.
+              type: string
+          request:
+            name: GetLevelsPlayedForUserRequest
+            query-parameters:
+              classroomHandle:
+                docs: The classroom's `_id`.
+                type: string
+              memberHandle:
+                docs: The classroom member's `_id`.
+                type: string
+          response: list<LevelSessionResponse>
+
+types:
+  
+  ClassroomResponseWithCode:
+    docs: Subset of properties listed here
+    properties:
+      _id: optional<commons.ObjectId>
+      name: optional<string>
+      members: optional<list<commons.ObjectId>>
+      ownerID: optional<commons.ObjectId>
+      description: optional<string>
+      code: optional<string>
+      codeCamel: optional<string>
+      courses: optional<list<Course>>
+      clanId: optional<commons.ObjectId>
+  
+  Course:
+    properties:
+      _id: optional<commons.ObjectId>
+      levels: optional<list<unknown>>
+      enrolled: optional<list<commons.ObjectId>>
+      instance_id: optional<commons.ObjectId>
+  
+  AceConfig:
+    properties:
+      language: optional<string>
+  
+  ClassroomStats:
+    properties:
+      _id: optional<commons.ObjectId>
+      stats: optional<ClassroomStatsInfo>
+  
+  ClassroomStatsInfo:
+    properties:
+      gamesCompleted: optional<double>
+      playtime: optional<double>
+  
+  LevelSessionResponse:
+    properties:
+      state: LevelSessionState
+      level: LevelSessionLevelInfo
+      levelID:
+        type: string
+        docs: Level slug like `wakka-maul`
+      creator: commons.ObjectId
+      playtime:
+        type: integer
+        docs: Time played in seconds.
+      changed: commons.Datetime
+      created: commons.Datetime
+      dateFirstCompleted: commons.Datetime
+      submitted:
+        type: boolean
+        docs: For arenas. Whether or not the level has been added to the ladder.
+      published:
+        type: boolean
+        docs: For shareable projects. Whether or not the project has been shared
+          with classmates.
+  
+  LevelSessionState: 
+    properties:
+      complete:
+        type: boolean
+  
+  LevelSessionLevelInfo: 
+    properties: 
+      original:
+        type: string
+        docs: The id for the level.

--- a/fern/api/definition/commons.yml
+++ b/fern/api/definition/commons.yml
@@ -1,4 +1,62 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
-
 types:
-  id: string
+  
+  UserResponse:
+    docs: Subset of properties listed here
+    properties:
+      _id: optional<ObjectId>
+      email: optional<string>
+      name: optional<string>
+      slug: optional<string>
+      role: optional<roleString>
+      stats: optional<UserStats>
+      oAuthIdentities: optional<list<OauthIdentity>>
+      subscription: optional<Subscription>
+      license: optional<License>
+
+  UserStats:
+    properties:
+      gamesCompleted: optional<double>
+      playTime: optional<double>
+
+  OauthIdentity:
+    properties:
+      provider: optional<string>
+      id: optional<string>
+
+  Subscription:
+    properties:
+      ends: optional<Datetime>
+      active: optional<boolean>
+
+  License:
+    properties:
+      ends: optional<Datetime>
+      active: optional<boolean>
+
+  ObjectId: string
+
+  Datetime: 
+    type: string
+    docs: | 
+      Has regex "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}\\:\\d{2}\\:\\d{2}\\.\\d{3}Z$/"
+
+  roleString:
+    docs: Usually either 'teacher' or 'student'
+    type: string
+
+  ClassroomResponse:
+    docs: Subset of properties listed here
+    properties:
+      _id: optional<ObjectId>
+      name: optional<string>
+      members: optional<list<ObjectId>>
+      ownerID: optional<ObjectId>
+      description: optional<string>
+      courses: optional<list<_InlinedType23>>
+      
+  _InlinedType23:
+    properties:
+      _id: optional<ObjectId>
+      levels: optional<list<unknown>>
+      enrolled: optional<list<ObjectId>>
+      instance_id: optional<ObjectId>

--- a/fern/api/definition/stats.yml
+++ b/fern/api/definition/stats.yml
@@ -1,0 +1,30 @@
+services:
+  http:
+    StatsService:
+      auth: true
+      base-path: ''
+      endpoints:
+        getPlaytimeStats:
+          path: /playtime-stats
+          method: GET
+          docs: Returns the playtime stats
+          response: PlaytimeStatsResponse
+
+        getLicenseStats:
+          path: /license-stats
+          method: GET
+          docs: Returns the license stats
+          response: LicenseStatsResponse
+
+types:
+  PlaytimeStatsResponse:
+    properties:
+      playTime: optional<double>
+      gamesPlayed: optional<double>
+
+  LicenseStatsResponse:
+    properties:
+      licenseDaysGranted: optional<double>
+      licenseDaysUsed: optional<double>
+      licenseDaysRemaining: optional<double>
+      activeLicenses: optional<double>

--- a/fern/api/definition/users.yml
+++ b/fern/api/definition/users.yml
@@ -1,0 +1,272 @@
+imports: 
+  commons: commons.yml
+  classrooms: classrooms.yml
+
+services:
+  http:
+    UsersService:
+      auth: true
+      base-path: /users
+      endpoints:
+
+        create:
+          path: ""
+          method: POST
+          docs: Creates a `User`.
+          request:
+            name: CreateUserRequest
+            body:
+              properties:
+                name: string
+                email: string
+                role: optional<string>
+                preferredLanguage: optional<string>
+                heroConfig: optional<HeroConfig>
+                birthday: optional<string>
+
+        get:
+          path: /{handle}
+          method: GET
+          docs: Returns a `User`.
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: GetUserRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+          response: commons.UserResponse
+
+        modifyUser:
+          path: /{handle}
+          method: PUT
+          docs: Modify name of a `User`
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: ModifyUserRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body:
+              properties:
+                name: string
+                birthday: optional<string>
+          response: commons.UserResponse
+      
+        getClassrooms:
+          path: /{handle}/classrooms
+          method: GET
+          docs: >-
+            Returns a list of `Classrooms` this user is in (if a student) or
+            owns (if a teacher).
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: GetUserClassroomsRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+          response: list<classrooms.ClassroomResponseWithCode>
+
+        setHero:
+          path: /{handle}/hero-config
+          method: PUT
+          docs: Set the user's hero.
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: SetHeroRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body:
+              properties:
+                thangType: optional<commons.ObjectId>
+          response: commons.UserResponse
+        
+        setAceConfig:
+          path: /{handle}/ace-config
+          method: PUT
+          docs: >-
+            Set the user's aceConfig (the settings for the in-game Ace code
+            editor), such as whether to enable autocomplete.
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: SetAceConfigRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body:
+              properties:
+                liveCompletion: optional<boolean>
+                behaviors: optional<boolean>
+                language: optional<string>
+          response: commons.UserResponse
+
+        addOauth2Identity:
+          path: /{handle}/o-auth-identities
+          method: POST
+          docs: >
+            Adds an OAuth2 identity to the user, so that they can be logged in
+            with that identity. You need to send the OAuth code or the access
+            token to this endpoint.
+
+            1. If no access token is provided, it will use your OAuth2 token URL
+            to exchange the given code for an access token.
+
+            2. Then it will use the access token (given by you, or received from
+            step 1) to look up the user on your service using the lookup URL,
+            and expects a JSON object in response with an `id` property.
+
+            3. It will then save that user `id` to the user in our db as a new
+            OAuthIdentity.
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: AddOauth2IdentityRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body:
+              properties:
+                provider: string
+                accessToken: optional<string>
+                code: optional<string>
+          response: commons.UserResponse
+
+        grantPremiumAccess:
+          path: /{handle}/subscription
+          method: PUT
+          docs: >
+            Grants a user premium access to the "Home" version up to a certain
+            time.
+            ```
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: GrantUserPremiumAccessRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body: commons.Subscription
+          response: commons.UserResponse
+
+        shortenSubscription:
+          path: /{handle}/shorten-subscription
+          method: PUT
+          docs: >
+            If the user already has a premium access up to a certain time, this
+            shortens/revokes his/her premium access.
+
+            If the ends is less than or equal to the current time, it revokes
+            the subscription and sets the end date to be the current time, else
+            it just shortens the subscription.
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: ShortenSubscriptionRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body: commons.Subscription
+          response: commons.UserResponse
+
+        grantClassroomAccess:
+          path: /{handle}/license
+          method: PUT
+          docs: >
+            Grants a user access to the "Classroom" version up to a certain
+            time.
+
+            Sets their role to "student".
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: GrantUserClassroomAccessRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body: commons.Subscription
+          response: commons.UserResponse
+        
+        shortenLicense:
+          path: /{handle}/shorten-license
+          method: PUT
+          docs: >
+            If the user already has access to the "Classroom" version up to a
+            certain time, this shortens/revokes his/her access.
+
+            If the ends is less than or equal to the current time, it revokes
+            the enrollment and sets the end date to be the current time, else it
+            just shortens the enrollment.
+          path-parameters:
+            handle:
+              docs: The document's `_id` or `slug`.
+              type: string
+          request:
+            name: ShortenLicenseRequest
+            query-parameters:
+              handle:
+                docs: The document's `_id` or `slug`.
+                type: string
+            body: commons.Subscription
+          response: commons.UserResponse
+
+        lookup:
+          path: /user-lookup/{property}/{value}
+          method: GET
+          docs: Redirects to `/{handle}` given a unique, identifying property
+          path-parameters:
+            property:
+              docs: >-
+                The property to lookup by. May either be `"israel-id"` or
+                `"name"`.
+              type: string
+            value:
+              docs: The value to be looked up.
+              type: string
+          request:
+            name: LookupUserRequest
+            query-parameters:
+              property:
+                docs: >-
+                  The property to lookup by. May either be `"israel-id"` or
+                  `"name"`.
+                type: string
+              value:
+                docs: The value to be looked up.
+                type: string
+
+types:
+  HeroConfig:
+    properties:
+      thangType: optional<commons.ObjectId>

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -2,7 +2,7 @@ groups:
   external:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.0.256
+        version: 0.0.258
         output:
           location: npm
           package-name: '@fern-api/codecombat'
@@ -10,6 +10,6 @@ groups:
         github:
           repository: fern-codecombat/codecombat-node
       - name: fernapi/fern-openapi
-        version: 0.0.15
+        version: 0.0.16
         github:
           repository: fern-codecombat/codecombat-openapi

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "codecombat",
-  "version": "0.3.11"
+  "version": "0.3.12-rc11"
 }

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,1186 @@
+{
+	"swaggerDoc": {
+		"swagger": "2.0",
+		"info": {
+			"version": "0.0.0",
+			"title": "CodeCombat API",
+			"description": "## Basics\n\n* Examples are in JavaScript on a Node/Express server with [request](https://github.com/request/request) installed.\n* Request and responses are in JSON.\n* API responses are the base resource being created/referenced. So, for example, all routes starting with `/api/users` return [User](#users) resources.\n\n## Client Setup\n\nWe currently do not have a way for you to create or set up your own API Client or OAuth Provider information. Please contact us directly to get started.\n\n## Client Authentication\n\nAPI routes must be called with Basic HTTP Authentication. You will receive a username (CLIENT_ID) and password (CLIENT_SECRET) upon creation of your API Client in our system. Provide those credentials with each API request.\n\n```javascript\nurl = 'https://codecombat.com/api/users'\njson = { name: 'A username' }\nauth = { name: CLIENT_ID, pass: CLIENT_SECRET }\nrequest.get({ url, json, auth }, (err, res) => console.log(res.statusCode, res.body))\n```\n\nWe strongly recommend using a secrets manager for storing your client secret. Plain text files like dotenv lead to accidental, costly leaks. Use [Doppler](https://doppler.com/) for a developer-friendly experience. AWS and Google Cloud have native solutions as well.\n\n## User Authentication\n\nTo authenticate a user on CodeCombat through your service, you will need to use the below OAuth 2 process. CodeCombat will act as the client, and your service will act as the provider.\nFirst, you will need to provide a trusted lookup URL and/or a token URL for the setup(See Client Setup above). Then the process from user account creation to log in will look like this:\n\n1. **Create the user** using [POST /api/users](#users/post_users).\n1. **Link the CodeCombat user to an OAuth identity** using [POST /api/users/:handle/o-auth-identities](#users/post_users__handle__o_auth_identities).\n    You can call this API with a code or an access token. If no access token is given, we will use the token URL to exchange the given code for an access token.\n    Then we call the lookup URL with the access token to receive the user information (`id`) from your system which is saved to the user in our db.\n1. **Log the user in** by redirecting them to [/auth/login-o-auth](#auth/get_auth_login_o_auth).\n    You can call this API with the code/access token, and we will get the user information from your system similarly to step 2.\n    Finally, we match this information with what is stored in our database in step 2. If everything checks out, the user is logged in and redirected to the home page.\n\nThere is also a [concrete example](https://s3.amazonaws.com/files.codecombat.com/codecombat_oauth_example.tar.gz) depicting the above process for better understanding. You can also refer to this [diagram](https://s3.amazonaws.com/files.codecombat.com/Example_OAuth_Flow.png).\n"
+		},
+		"host": "codecombat.com",
+		"basePath": "/api",
+		"schemes": ["https"],
+		"consumes": ["application/json"],
+		"produces": ["application/json"],
+		"paths": {
+			"/auth/login-o-auth": {
+				"get": {
+					"tags": ["auth"],
+					"description": "Logs a [user](#users) in.",
+					"parameters": [{
+						"name": "provider",
+						"in": "query",
+						"required": true,
+						"type": "string",
+						"description": "Your OAuth Provider ID"
+					}, {
+						"name": "accessToken",
+						"in": "query",
+						"type": "string",
+						"description": "Will be passed through your lookup URL to get the user ID. Required if no `code`."
+					}, {
+						"name": "code",
+						"type": "string",
+						"in": "query",
+						"description": "Will be passed to the OAuth token endpoint to get a token. Required if no `accessToken`."
+					}, {
+						"name": "redirect",
+						"type": "string",
+						"in": "query",
+						"description": "Override where the user will navigate to after successfully logging in."
+					}, {
+						"name": "errorRedirect",
+						"type": "string",
+						"in": "query",
+						"description": "If an error happens, redirects the user to this url, with at least query parameters `code`, `errorName` and `message`."
+					}],
+					"responses": {
+						"302": {
+							"description": "Redirects the user to a landing page after having logged them in."
+						}
+					}
+				}
+			},
+			"/users": {
+				"post": {
+					"tags": ["users"],
+					"description": "Creates a `User`.\n\n```javascript\nurl = 'https://codecombat.com/api/users'\njson = { email: '<a href=" / cdn - cgi / l / email - protection " class="
+					__cf_email__ " data-cfemail="
+					adccc3edc8c0ccc4c183cec2c0 ">[email&#160;protected]</a>', name: 'Some Username', role: 'student' }\nrequest.post({ url, json, auth })\n```\n",
+					"parameters": [{
+						"name": "user",
+						"in": "body",
+						"schema": {
+							"type": "object",
+							"required": ["name", "email"],
+							"properties": {
+								"name": {
+									"type": "string"
+								},
+								"email": {
+									"type": "string"
+								},
+								"role": {
+									"type": "string",
+									"description": "`\"student\"` or `\"teacher\"`. If unset, a home user will be created, unable to join classrooms.",
+									"enum": ["student", "teacher"]
+								},
+								"preferredLanguage": {
+									"type": "string"
+								},
+								"heroConfig": {
+									"type": "object",
+									"properties": {
+										"thangType": {
+											"$ref": "#/definitions/objectIdString"
+										}
+									}
+								},
+								"birthday": {
+									"type": "string"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"201": {
+							"description": "The created user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				}
+			},
+			"/users/{handle}": {
+				"get": {
+					"tags": ["users"],
+					"description": "Returns a `User`.",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "includePlayTime",
+						"in": "query",
+						"description": "Set to non-empty string to include stats.playTime in response",
+						"required": false,
+						"type": "string"
+					}],
+					"responses": {
+						"200": {
+							"description": "The requested user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				},
+				"put": {
+					"tags": ["users"],
+					"description": "Modify name of a `User`",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "user",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["name"],
+							"properties": {
+								"name": {
+									"type": "string",
+									"description": "Set to new name string"
+								},
+								"birthday": {
+									"type": "string",
+									"description": "Set the birthday"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The affected user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				}
+			},
+			"/users/{handle}/classrooms": {
+				"get": {
+					"tags": ["users"],
+					"description": "Returns a list of `Classrooms` this user is in (if a student) or owns (if a teacher).",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "retMemberLimit",
+						"in": "query",
+						"description": "limit the return number of members for each classroom",
+						"required": false,
+						"type": "number"
+					}],
+					"responses": {
+						"200": {
+							"description": "The requested classrooms",
+							"schema": {
+								"type": "array",
+								"items": {
+									"$ref": "#/definitions/ClassroomResponseWithCode"
+								}
+							}
+						}
+					}
+				}
+			},
+			"/users/{handle}/hero-config": {
+				"put": {
+					"tags": ["users"],
+					"description": "Set the user's hero.",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "heroConfig",
+						"in": "body",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"thangType": {
+									"$ref": "#/definitions/objectIdString"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The affected user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				}
+			},
+			"/users/{handle}/ace-config": {
+				"put": {
+					"tags": ["users"],
+					"description": "Set the user's aceConfig (the settings for the in-game Ace code editor), such as whether to enable autocomplete.",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "aceConfig",
+						"in": "body",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"liveCompletion": {
+									"type": "boolean",
+									"required": false,
+									"description": "controls whether autocompletion snippets show up, the default value is true"
+								},
+								"behaviors": {
+									"type": "boolean",
+									"required": false,
+									"description": "controls whether things like automatic parenthesis and quote completion happens, the default value is false"
+								},
+								"language": {
+									"type": "string",
+									"required": false,
+									"description": "only for home users, should be one of [\"python\", \"javascript\", \"cpp\", \"lua\", \"coffeescript\"] right now"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The affected user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				}
+			},
+			"/users/{handle}/o-auth-identities": {
+				"post": {
+					"tags": ["users"],
+					"description": "Adds an OAuth2 identity to the user, so that they can be logged in with that identity. You need to send the OAuth code or the access token to this endpoint.\n\n1. If no access token is provided, it will use your OAuth2 token URL to exchange the given code for an access token.\n\n1. Then it will use the access token (given by you, or received from step 1) to look up the user on your service using the lookup URL, and expects a JSON object in response with an `id` property.\n\n1. It will then save that user `id` to the user in our db as a new OAuthIdentity.\n\n\n```javascript\nurl = `https://codecombat.com/api/users/${userID}/o-auth-identities`\nOAUTH_PROVIDER_ID = 'xyz'\njson = { provider: OAUTH_PROVIDER_ID, accessToken: '1234' }\nrequest.post({ url, json, auth}, (err, res) => {\n  console.log(res.body.oAuthIdentities) // [ { provider: 'xyx', id: 'abcd' } ]\n})\n```\n\nIn this example, we call your lookup URL (let's say, `https://oauth.provider/user?t=<%= accessToken %>`) with the access token (`1234`). The lookup URL returns `{ id: 'abcd' }` in this case, which we save to the user in our db.\n",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "oAuthIdentity",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["provider"],
+							"properties": {
+								"provider": {
+									"type": "string",
+									"description": "Your OAuth Provider ID."
+								},
+								"accessToken": {
+									"type": "string",
+									"description": "Will be passed through your lookup URL to get the user ID. Required if no `code`."
+								},
+								"code": {
+									"type": "string",
+									"description": "Will be passed to the OAuth token endpoint to get a token. Required if no `accessToken`."
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The affected user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				}
+			},
+			"/users/{handle}/subscription": {
+				"put": {
+					"tags": ["users"],
+					"description": "Grants a user premium access to the \"Home\" version up to a certain time.\n\n\n```javascript\nurl = `https://codecombat.com/api/users/${userID}/subscription`\njson = { ends: new Date('2017-01-01').toISOString() }\nrequest.put({ url, json, auth }, (err, res) => {\n  console.log(res.body.subscription) // { ends: '2017-01-01T00:00:00.000Z', active: true }\n})\n```\n",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "subscription",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["ends"],
+							"properties": {
+								"ends": {
+									"$ref": "#/definitions/datetimeString"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The affected user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				}
+			},
+			"/users/{handle}/shorten-subscription": {
+				"put": {
+					"tags": ["users"],
+					"description": "If the user already has a premium access up to a certain time, this shortens/revokes his/her premium access.\nIf the ends is less than or equal to the current time, it revokes the subscription and sets the end date to be the current time, else it just shortens the subscription.\n\n\n```javascript\nurl = `https://codecombat.com/api/users/${userID}/shorten-subscription`\njson = { ends: new Date().toISOString() }\nrequest.put({ url, json, auth }, (err, res) => {\n  console.log(res.body.subscription.active) // false\n})\n```\n",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "subscription",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["ends"],
+							"properties": {
+								"ends": {
+									"$ref": "#/definitions/datetimeString"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The affected user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				}
+			},
+			"/users/{handle}/license": {
+				"put": {
+					"tags": ["users"],
+					"description": "Grants a user access to the \"Classroom\" version up to a certain time.\nSets their role to \"student\".\n\n\n```javascript\nurl = `https://codecombat.com/api/users/${userID}/license`\njson = { ends: new Date('2017-01-01').toISOString() }\nrequest.put({ url, json, auth }, (err, res) => {\n  console.log(res.body.license) // { ends: '2017-01-01T00:00:00.000Z', active: true }\n})\n```\n",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "license",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["ends"],
+							"properties": {
+								"ends": {
+									"$ref": "#/definitions/datetimeString"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The affected user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				}
+			},
+			"/users/{handle}/shorten-license": {
+				"put": {
+					"tags": ["users"],
+					"description": "If the user already has access to the \"Classroom\" version up to a certain time, this shortens/revokes his/her access.\nIf the ends is less than or equal to the current time, it revokes the enrollment and sets the end date to be the current time, else it just shortens the enrollment.\n\n\n```javascript\nurl = `https://codecombat.com/api/users/${userID}/shorten-license`\njson = { ends: new Date().toISOString() }\nrequest.put({ url, json, auth }, (err, res) => {\n  console.log(res.body.license.active) // false\n})\n```\n",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "license",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["ends"],
+							"properties": {
+								"ends": {
+									"$ref": "#/definitions/datetimeString"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The affected user",
+							"schema": {
+								"$ref": "#/definitions/UserResponse"
+							}
+						}
+					}
+				}
+			},
+			"/clan/{handle}/members": {
+				"put": {
+					"tags": ["clans"],
+					"description": "Upserts a user into the clan.",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "member",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["userId"],
+							"properties": {
+								"userId": {
+									"description": "The `_id` or `slug` of the user to add to the clan.",
+									"type": "string"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The clan with the member added.",
+							"schema": {
+								"$ref": "#/definitions/ClanResponse"
+							}
+						}
+					}
+				}
+			},
+			"/classrooms": {
+				"post": {
+					"tags": ["classrooms"],
+					"description": "Creates a new empty `Classroom`.",
+					"parameters": [{
+						"name": "classroom",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["name", "ownerID", "aceConfig"],
+							"properties": {
+								"name": {
+									"type": "string",
+									"description": "Name of the classroom"
+								},
+								"ownerID": {
+									"$ref": "#/definitions/objectIdString",
+									"description": "The `_id` of the teacher for whom classroom is being created"
+								},
+								"aceConfig": {
+									"type": "object",
+									"properties": {
+										"language": {
+											"type": "string",
+											"description": "Programming language for the classroom"
+										}
+									}
+								}
+							}
+						}
+					}],
+					"responses": {
+						"201": {
+							"description": "The created classroom",
+							"schema": {
+								"$ref": "#/definitions/ClassroomResponseWithCode"
+							}
+						}
+					}
+				},
+				"get": {
+					"tags": ["classrooms"],
+					"description": "Returns the classroom details for a class code.",
+					"parameters": [{
+						"name": "code",
+						"in": "query",
+						"type": "string",
+						"required": true,
+						"description": "The classroom's `code`."
+					}, {
+						"name": "retMemberLimit",
+						"in": "query",
+						"description": "limit the return number of members for the classroom",
+						"required": false,
+						"type": "number"
+					}],
+					"responses": {
+						"200": {
+							"description": "The classroom details.",
+							"schema": {
+								"$ref": "#/definitions/ClassroomResponseWithCode"
+							}
+						}
+					}
+				}
+			},
+			"/classrooms/{handle}/members": {
+				"put": {
+					"tags": ["classrooms"],
+					"description": "Upserts a user into the classroom.",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "member",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["code", "userId"],
+							"properties": {
+								"code": {
+									"type": "string",
+									"description": "The code for joining this classroom"
+								},
+								"userId": {
+									"description": "The `_id` or `slug` of the user to add to the class.",
+									"type": "string"
+								},
+								"retMemberLimit": {
+									"description": "limit the return number of members for the classroom, the default value is 1000",
+									"type": "number"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The classroom with the member added.",
+							"schema": {
+								"$ref": "#/definitions/ClassroomResponse"
+							}
+						}
+					}
+				},
+				"delete": {
+					"tags": ["classrooms"],
+					"description": "Remove a user from the classroom.",
+					"parameters": [{
+						"$ref": "#/parameters/handlePathParameter"
+					}, {
+						"name": "member",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["userId"],
+							"properties": {
+								"userId": {
+									"description": "The `_id` or `slug` of the user to remove from the class.",
+									"type": "string"
+								},
+								"retMemberLimit": {
+									"description": "limit the return number of members for the classroom, the default value is 1000",
+									"type": "number"
+								}
+							}
+						}
+					}],
+					"responses": {
+						"200": {
+							"description": "The classroom with the member removed.",
+							"schema": {
+								"$ref": "#/definitions/ClassroomResponse"
+							}
+						}
+					}
+				}
+			},
+			"/classrooms/{classroomHandle}/courses/{courseHandle}/enrolled": {
+				"put": {
+					"tags": ["classrooms"],
+					"description": "Enrolls a user in a course in a classroom.\nIf the course is paid, user must have an active license.\nUser must be a member of the classroom.\n",
+					"parameters": [{
+						"name": "classroomHandle",
+						"in": "path",
+						"type": "string",
+						"required": true,
+						"description": "The classroom's `_id`."
+					}, {
+						"name": "courseHandle",
+						"in": "path",
+						"type": "string",
+						"required": true,
+						"description": "The course's `_id`."
+					}, {
+						"name": "userId",
+						"description": "The `_id` or `slug` of the user to add to the class.",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["userId"],
+							"properties": {
+								"userId": {
+									"$ref": "#/definitions/objectIdString"
+								}
+							}
+						}
+					}, {
+						"name": "retMemberLimit",
+						"in": "query",
+						"description": "limit the return number of members for the classroom, the default value is 1000",
+						"required": false,
+						"type": "number"
+					}],
+					"responses": {
+						"200": {
+							"description": "The classroom with the user enrolled.",
+							"schema": {
+								"$ref": "#/definitions/ClassroomResponse"
+							}
+						}
+					}
+				}
+			},
+			"/classrooms/{classroomHandle}/courses/{courseHandle}/remove-enrolled": {
+				"put": {
+					"tags": ["classrooms"],
+					"description": "Removes an enrolled user from a course in a classroom.\n",
+					"parameters": [{
+						"name": "classroomHandle",
+						"in": "path",
+						"type": "string",
+						"required": true,
+						"description": "The classroom's `_id`."
+					}, {
+						"name": "courseHandle",
+						"in": "path",
+						"type": "string",
+						"required": true,
+						"description": "The course's `_id`."
+					}, {
+						"name": "userId",
+						"description": "The `_id` or `slug` of the user to remove from the course.",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"required": ["userId"],
+							"properties": {
+								"userId": {
+									"$ref": "#/definitions/objectIdString"
+								}
+							}
+						}
+					}, {
+						"name": "retMemberLimit",
+						"in": "query",
+						"description": "limit the return number of members for the classroom, the default value is 1000",
+						"required": false,
+						"type": "number"
+					}],
+					"responses": {
+						"200": {
+							"description": "The classroom with the user removed from the course.",
+							"schema": {
+								"$ref": "#/definitions/ClassroomResponse"
+							}
+						}
+					}
+				}
+			},
+			"/classrooms/{classroomHandle}/stats": {
+				"get": {
+					"tags": ["classrooms"],
+					"description": "Returns a list of all members stats for the classroom.\n",
+					"parameters": [{
+						"name": "classroomHandle",
+						"in": "path",
+						"type": "string",
+						"required": true,
+						"description": "The classroom's `_id`."
+					}, {
+						"name": "project",
+						"in": "query",
+						"type": "string",
+						"description": "If specified, include only the specified projection of returned stats; else, return all stats. Format as a comma-separated list, like `creator,playtime,state.complete`.\n",
+						"required": false
+					}, {
+						"name": "memberLimit",
+						"in": "query",
+						"type": "number",
+						"description": "Limit the return member number. the default value is 10, and the max value is 100",
+						"required": false
+					}, {
+						"name": "memberSkip",
+						"in": "query",
+						"type": "number",
+						"description": "Skip the members that doesn't need to return, for pagination\n",
+						"required": false
+					}],
+					"responses": {
+						"200": {
+							"description": "The members stats for the classroom.",
+							"schema": {
+								"type": "array",
+								"items": {
+									"type": "object",
+									"properties": {
+										"_id": {
+											"$ref": "#/definitions/objectIdString"
+										},
+										"stats": {
+											"type": "object",
+											"properties": {
+												"gamesCompleted": {
+													"type": "number"
+												},
+												"playtime": {
+													"type": "number",
+													"description": "Total play time in seconds"
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			"/classrooms/{classroomHandle}/members/{memberHandle}/sessions": {
+				"get": {
+					"tags": ["classrooms"],
+					"description": "Returns a list of all levels played by the user for the classroom.\n",
+					"parameters": [{
+						"name": "classroomHandle",
+						"in": "path",
+						"type": "string",
+						"required": true,
+						"description": "The classroom's `_id`."
+					}, {
+						"name": "memberHandle",
+						"in": "path",
+						"type": "string",
+						"required": true,
+						"description": "The classroom member's `_id`."
+					}],
+					"responses": {
+						"200": {
+							"description": "The classroom with the user enrolled.",
+							"schema": {
+								"type": "array",
+								"items": {
+									"$ref": "#/definitions/LevelSessionResponse"
+								}
+							}
+						}
+					}
+				}
+			},
+			"/user-lookup/{property}/{value}": {
+				"get": {
+					"tags": ["users"],
+					"description": "Redirects to `/users/{handle}` given a unique, identifying property",
+					"parameters": [{
+						"name": "property",
+						"in": "path",
+						"type": "string",
+						"required": true,
+						"description": "The property to lookup by. May either be `\"israel-id\"` or `\"name\"`."
+					}, {
+						"name": "value",
+						"in": "path",
+						"type": "string",
+						"required": true,
+						"description": "The value to be looked up."
+					}],
+					"responses": {
+						"301": {
+							"description": "Redirect to `User` resource at `/users/{handle}`"
+						}
+					}
+				}
+			},
+			"/playtime-stats": {
+				"get": {
+					"tags": ["stats"],
+					"description": "Returns the playtime stats",
+					"parameters": [{
+						"name": "startDate",
+						"in": "query",
+						"description": "Earliest an included user was created",
+						"required": false,
+						"type": "string"
+					}, {
+						"name": "endDate",
+						"in": "query",
+						"description": "Latest an included user was created",
+						"required": false,
+						"type": "string"
+					}, {
+						"name": "country",
+						"in": "query",
+						"description": "Filter by country string",
+						"required": false,
+						"type": "string"
+					}],
+					"responses": {
+						"200": {
+							"description": "Returns the playtime stats accross all owned users.",
+							"schema": {
+								"$ref": "#/definitions/PlaytimeStatsResponse"
+							}
+						}
+					}
+				}
+			},
+			"/license-stats": {
+				"get": {
+					"tags": ["stats"],
+					"description": "Returns the license stats",
+					"responses": {
+						"200": {
+							"description": "Returns the license stats for classroom/home subscription licenses.",
+							"schema": {
+								"$ref": "#/definitions/LicenseStatsResponse"
+							}
+						}
+					}
+				}
+			}
+		},
+		"parameters": {
+			"handlePathParameter": {
+				"name": "handle",
+				"in": "path",
+				"type": "string",
+				"required": true,
+				"description": "The document's `_id` or `slug`."
+			}
+		},
+		"tags": [{
+			"name": "users"
+		}],
+		"securityDefinitions": {
+			"basicAuth": {
+				"type": "basic",
+				"description": "HTTP Basic Authentication. We will need to provide you with your client ID and secret."
+			}
+		},
+		"security": [{
+			"basicAuth": []
+		}],
+		"definitions": {
+			"roleString": {
+				"type": "string",
+				"description": "Usually either 'teacher' or 'student'"
+			},
+			"datetimeString": {
+				"type": "string",
+				"pattern": "/^\\d{4}-\\d{2}-\\d{2}T\\d{2}\\:\\d{2}\\:\\d{2}\\.\\d{3}Z$/"
+			},
+			"objectIdString": {
+				"type": "string",
+				"pattern": "/^[0-9a-f]{24}$/"
+			},
+			"UserResponse": {
+				"type": "object",
+				"title": "UserResponse",
+				"description": "Subset of properties listed here",
+				"properties": {
+					"_id": {
+						"$ref": "#/definitions/objectIdString"
+					},
+					"email": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"slug": {
+						"type": "string"
+					},
+					"role": {
+						"$ref": "#/definitions/roleString"
+					},
+					"stats": {
+						"type": "object",
+						"properties": {
+							"gamesCompleted": {
+								"type": "number"
+							},
+							"concepts": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "number"
+								}
+							},
+							"playTime": {
+								"type": "number",
+								"description": "Included only when specifically requested on the endpoint"
+							}
+						}
+					},
+					"oAuthIdentities": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"provider": {
+									"type": "string"
+								},
+								"id": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"subscription": {
+						"type": "object",
+						"properties": {
+							"ends": {
+								"$ref": "#/definitions/datetimeString"
+							},
+							"active": {
+								"type": "boolean"
+							}
+						}
+					},
+					"license": {
+						"type": "object",
+						"properties": {
+							"ends": {
+								"$ref": "#/definitions/datetimeString"
+							},
+							"active": {
+								"type": "boolean"
+							}
+						}
+					}
+				}
+			},
+			"ClassroomResponse": {
+				"type": "object",
+				"title": "ClassroomResponse",
+				"description": "Subset of properties listed here",
+				"properties": {
+					"_id": {
+						"$ref": "#/definitions/objectIdString"
+					},
+					"name": {
+						"type": "string"
+					},
+					"members": {
+						"type": "array",
+						"items": {
+							"$ref": "#/definitions/objectIdString"
+						}
+					},
+					"ownerID": {
+						"$ref": "#/definitions/objectIdString"
+					},
+					"description": {
+						"type": "string"
+					},
+					"courses": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"_id": {
+									"$ref": "#/definitions/objectIdString"
+								},
+								"levels": {
+									"type": "array",
+									"items": {
+										"type": "object"
+									}
+								},
+								"enrolled": {
+									"type": "array",
+									"items": {
+										"$ref": "#/definitions/objectIdString"
+									}
+								},
+								"instance_id": {
+									"$ref": "#/definitions/objectIdString"
+								}
+							}
+						}
+					}
+				}
+			},
+			"ClassroomResponseWithCode": {
+				"type": "object",
+				"title": "ClassroomResponseWithCode",
+				"description": "Subset of properties listed here",
+				"properties": {
+					"_id": {
+						"$ref": "#/definitions/objectIdString"
+					},
+					"name": {
+						"type": "string"
+					},
+					"members": {
+						"type": "array",
+						"items": {
+							"$ref": "#/definitions/objectIdString"
+						}
+					},
+					"ownerID": {
+						"$ref": "#/definitions/objectIdString"
+					},
+					"description": {
+						"type": "string"
+					},
+					"code": {
+						"type": "string"
+					},
+					"codeCamel": {
+						"type": "string"
+					},
+					"courses": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"_id": {
+									"$ref": "#/definitions/objectIdString"
+								},
+								"levels": {
+									"type": "array",
+									"items": {
+										"type": "object"
+									}
+								},
+								"enrolled": {
+									"type": "array",
+									"items": {
+										"$ref": "#/definitions/objectIdString"
+									}
+								},
+								"instance_id": {
+									"$ref": "#/definitions/objectIdString"
+								}
+							}
+						}
+					},
+					"clanId": {
+						"$ref": "#/definitions/objectIdString"
+					}
+				}
+			},
+			"PlaytimeStatsResponse": {
+				"type": "object",
+				"properties": {
+					"playTime": {
+						"type": "number",
+						"description": "Total play time in seconds"
+					},
+					"gamesPlayed": {
+						"type": "number",
+						"description": "Number of levels played"
+					}
+				}
+			},
+			"LicenseStatsResponse": {
+				"type": "object",
+				"properties": {
+					"licenseDaysGranted": {
+						"type": "number",
+						"description": "Total number of license days granted"
+					},
+					"licenseDaysUsed": {
+						"type": "number",
+						"description": "Number of license days used"
+					},
+					"licenseDaysRemaining": {
+						"type": "number",
+						"description": "Number of license days remaining"
+					},
+					"activeLicenses": {
+						"type": "number",
+						"description": "Number of active/valid licenses"
+					}
+				}
+			},
+			"LevelSessionResponse": {
+				"type": "object",
+				"properties": {
+					"state": {
+						"type": "object",
+						"properties": {
+							"complete": {
+								"type": "boolean"
+							}
+						}
+					},
+					"level": {
+						"type": "object",
+						"properties": {
+							"original": {
+								"type": "string",
+								"description": "The id for the level."
+							}
+						}
+					},
+					"levelID": {
+						"type": "string",
+						"description": "Level slug like `wakka-maul`"
+					},
+					"creator": {
+						"type": "string",
+						"$ref": "#/definitions/objectIdString"
+					},
+					"playtime": {
+						"type": "integer",
+						"description": "Time played in seconds."
+					},
+					"changed": {
+						"$ref": "#/definitions/datetimeString"
+					},
+					"created": {
+						"$ref": "#/definitions/datetimeString"
+					},
+					"dateFirstCompleted": {
+						"$ref": "#/definitions/datetimeString"
+					},
+					"submitted": {
+						"type": "boolean",
+						"description": "For arenas. Whether or not the level has been added to the ladder."
+					},
+					"published": {
+						"type": "boolean",
+						"description": "For shareable projects. Whether or not the project has been shared with classmates."
+					}
+				}
+			},
+			"ClanResponse": {
+				"type": "object",
+				"title": "ClanResponse",
+				"description": "Subset of properties listed here",
+				"properties": {
+					"_id": {
+						"$ref": "#/definitions/objectIdString"
+					},
+					"name": {
+						"type": "string"
+					},
+					"displayName": {
+						"type": "string"
+					},
+					"members": {
+						"type": "array",
+						"items": {
+							"$ref": "#/definitions/objectIdString"
+						}
+					},
+					"ownerID": {
+						"$ref": "#/definitions/objectIdString"
+					},
+					"description": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					},
+					"kind": {
+						"type": "string"
+					},
+					"metadata": {
+						"type": "object"
+					}
+				}
+			}
+		}
+	},
+	"customOptions": {
+		"defaultModelRendering": "model"
+	}
+}


### PR DESCRIPTION
CodeCombat provides a hosted `swagger.json` on their docs website. We were able to use Fern's Swagger Importer and generate about 80% of the definition and then had to manually specify some names to finish the full conversion.