### PR TITLE
fix: upgrade `fern` and reimport query params

### DIFF
--- a/fern/api/definition/auth.yml
+++ b/fern/api/definition/auth.yml
@@ -11,19 +11,26 @@ services:
           request: 
             name: LoginUserRequest
             query-parameters:
-              provider: 
-                type: string
+              provider:
                 docs: Your OAuth Provider ID
-              accessToken: 
+                type: string
+              accessToken:
+                docs: >-
+                  Will be passed through your lookup URL to get the user ID.
+                  Required if no `code`.
                 type: optional<string>
-                docs: Will be passed through your lookup URL to get the user ID. Required if no code.
-              code: 
+              code:
+                docs: >-
+                  Will be passed to the OAuth token endpoint to get a token.
+                  Required if no `accessToken`.
                 type: optional<string>
-                docs: Will be passed to the OAuth token endpoint to get a token. Required if no accessToken.
-              redirect: 
+              redirect:
+                docs: >-
+                  Override where the user will navigate to after successfully
+                  logging in.
                 type: optional<string>
-                docs: Override where the user will navigate to after successfully logging in.
-              errorRedirect: 
-                type: optional<string> 
-                docs: | 
-                  If an error happens, redirects the user to this url, with at least query parameters code, errorName and message.
+              errorRedirect:
+                docs: >-
+                  If an error happens, redirects the user to this url, with at
+                  least query parameters `code`, `errorName` and `message`.
+                type: optional<string>

--- a/fern/api/definition/classrooms.yml
+++ b/fern/api/definition/classrooms.yml
@@ -13,13 +13,13 @@ services:
           docs: Returns the classroom details for a class code.
           request: 
             name: GetClassroomRequest
-            query-parameters: 
-              code: 
+            query-parameters:
+              code:
+                docs: The classroom's `code`.
                 type: string
-                docs: The classroom’s `code`
-              retMemberLimit: 
-                type: integer
+              retMemberLimit:
                 docs: limit the return number of members for the classroom
+                type: optional<double>
           response: ClassroomResponseWithCode
         
         create:
@@ -84,12 +84,11 @@ services:
           request:
             name: EnrollUserRequest
             query-parameters:
-              classroomHandle:
-                docs: The classroom's `_id`.
-                type: string
-              courseHandle:
-                docs: The course's `_id`.
-                type: string
+              retMemberLimit:
+                docs: >-
+                  limit the return number of members for the classroom, the
+                  default value is 1000
+                type: optional<double>
             body:
               properties:
                 userId: commons.ObjectId
@@ -110,12 +109,11 @@ services:
           request:
             name: UnenrollUserRequest
             query-parameters:
-              classroomHandle:
-                docs: The classroom's `_id`.
-                type: string
-              courseHandle:
-                docs: The course's `_id`.
-                type: string
+              retMemberLimit:
+                docs: >-
+                  limit the return number of members for the classroom, the
+                  default value is 1000
+                type: optional<double>
             body:
               properties:
                 userId: commons.ObjectId
@@ -133,9 +131,21 @@ services:
           request:
             name: ClassroomStatsRequest
             query-parameters:
-              classroomHandle:
-                docs: The classroom's `_id`.
-                type: string
+              project:
+                docs: >
+                  If specified, include only the specified projection of
+                  returned stats; else, return all stats. Format as a
+                  comma-separated list, like `creator,playtime,state.complete`.
+                type: optional<string>
+              memberLimit:
+                docs: >-
+                  Limit the return member number. the default value is 10, and
+                  the max value is 100
+                type: optional<double>
+              memberSkip:
+                docs: |
+                  Skip the members that doesn't need to return, for pagination
+                type: optional<double>
           response: list<ClassroomStats>
           
         getLevelsPlayedForUser:
@@ -150,15 +160,6 @@ services:
             memberHandle:
               docs: The classroom member's `_id`.
               type: string
-          request:
-            name: GetLevelsPlayedForUserRequest
-            query-parameters:
-              classroomHandle:
-                docs: The classroom's `_id`.
-                type: string
-              memberHandle:
-                docs: The classroom member's `_id`.
-                type: string
           response: list<LevelSessionResponse>
 
 types:

--- a/fern/api/definition/stats.yml
+++ b/fern/api/definition/stats.yml
@@ -8,6 +8,18 @@ services:
           path: /playtime-stats
           method: GET
           docs: Returns the playtime stats
+          request: 
+            name: GetPlaytimeStatsRequest
+            query-parameters:
+              startDate:
+                docs: Earliest an included user was created
+                type: optional<string>
+              endDate:
+                docs: Latest an included user was created
+                type: optional<string>
+              country:
+                docs: Filter by country string
+                type: optional<string>
           response: PlaytimeStatsResponse
 
         getLicenseStats:

--- a/fern/api/definition/users.yml
+++ b/fern/api/definition/users.yml
@@ -34,6 +34,10 @@ services:
               type: string
           request:
             name: GetUserRequest
+            query-parameters:
+              includePlayTime:
+                docs: Set to non-empty string to include stats.playTime in response
+                type: optional<string>
           response: commons.UserResponse
 
         modifyUser:
@@ -64,6 +68,10 @@ services:
               type: string
           request:
             name: GetUserClassroomsRequest
+            query-parameters:
+              retMemberLimit:
+                docs: limit the return number of members for each classroom
+                type: optional<double>
           response: list<classrooms.ClassroomResponseWithCode>
 
         setHero:
@@ -212,17 +220,6 @@ services:
             value:
               docs: The value to be looked up.
               type: string
-          request:
-            name: LookupUserRequest
-            query-parameters:
-              property:
-                docs: >-
-                  The property to lookup by. May either be `"israel-id"` or
-                  `"name"`.
-                type: string
-              value:
-                docs: The value to be looked up.
-                type: string
 
 types:
   HeroConfig:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "codecombat",
-  "version": "0.3.12-rc11"
+  "version": "0.3.12-rc12"
 }


### PR DESCRIPTION
The fern upgrade has bug fixes related to reading query parameters from open api and writing them out to the fern definition.